### PR TITLE
adds tokio_util to test to resolve local build/test error from compiler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ required-features = ["tokio", "tungstenite"]
 
 [[test]]
 name = "network"
-required-features = ["tokio_util"]
+required-features = ["tokio", "tungstenite"]
 
 [features]
 tokio = ["dep:tokio", "dep:tokio-util"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ required-features = ["tokio", "tungstenite"]
 
 [[test]]
 name = "network"
+required-features = ["tokio_util"]
 
 [features]
 tokio = ["dep:tokio", "dep:tokio-util"]


### PR DESCRIPTION
running `cargo test` locally was throwing an error, so I dug around and noticed that tokio_util was referenced in the network test target, but not defined in Cargo.toml - so I added it to fix my local build. Not sure why CI didn't see it...