### PR TITLE
Better websockets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ required-features = ["tokio"]
 
 [[test]]
 name = "interop"
-required-features = ["tokio", "tungstenite"]
+required-features = ["tokio", "tungstenite", "axum"]
 
 [[test]]
 name = "network"
@@ -23,10 +23,12 @@ required-features = ["tokio", "tungstenite"]
 
 [features]
 tokio = ["dep:tokio", "dep:tokio-util"]
+axum = ["dep:axum", "dep:tokio", "dep:tokio-util"]
 tungstenite = ["dep:tungstenite"]
 
 [dependencies]
 automerge = { version = "0.4.1" }
+axum = { version = "0.6.18", features = ["ws"], optional = true }
 uuid = { version = "1.2.2"}
 crossbeam-channel = { version = "0.5.8" }
 parking_lot = { version = "0.12.1" }
@@ -46,7 +48,7 @@ tempfile = "3.6.0"
 [dev-dependencies]
 clap = { version = "4.2.5", features = ["derive"] }
 reqwest = { version = "0.11.17", features = ["json", "blocking"], default-features = false }
-axum = { version = "0.6.18" }
+axum = { version = "0.6.18", features = ["ws"] }
 axum-macros = "0.3.7"
 tokio = { version = "1.27", features = ["full"] }
 tokio-stream = { version = "0.1" }

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -7,11 +7,12 @@ use tokio_util::codec::{Decoder, Encoder};
 use crate::{repo::RepoHandle, ConnDirection};
 use crate::{Message, NetworkError};
 
-#[cfg(feature = "tungstenite")]
-use futures::{Future, FutureExt, Sink, SinkExt, Stream, StreamExt};
+use futures::StreamExt;
 
 mod fs_storage;
 pub use fs_storage::FsStorage;
+
+mod websocket;
 
 impl RepoHandle {
     /// Connect a tokio io object
@@ -33,148 +34,6 @@ impl RepoHandle {
         self.connect_stream(stream, sink, direction).await?;
 
         Ok(())
-    }
-
-    /// Connect a websocket
-    ///
-    /// This function waits until the initial handshake is complete and then returns a future which
-    /// must be driven to completion to keep the connection alive. The returned future is required
-    /// so that we continue to respond to pings from the server which will otherwise disconnect us.
-    ///
-    /// ## Example
-    ///
-    /// ```no_run
-    /// use automerge_repo::{Repo, RepoHandle, ConnDirection, Storage};
-    ///
-    /// #[tokio::main]
-    /// async fn main() {
-    ///    let storage: Box<dyn Storage> = unimplemented!();
-    ///    let repo = Repo::new(None, storage);
-    ///    let handle = repo.run();
-    ///    let (conn, _) = tokio_tungstenite::connect_async("ws://localhost:8080").await.unwrap();
-    ///    let conn_driver = handle.connect_tungstenite(conn, ConnDirection::Outgoing).await.unwrap();
-    ///    tokio::spawn(async move {
-    ///        if let Err(e) = conn_driver.await {
-    ///            eprintln!("Error running repo connection: {}", e);
-    ///        }
-    ///    });
-    ///    // ...
-    /// }
-    /// ```
-    #[cfg(feature = "tungstenite")]
-    pub async fn connect_tungstenite<S>(
-        &self,
-        stream: S,
-        direction: ConnDirection,
-    ) -> Result<impl Future<Output = Result<(), CodecError>>, CodecError>
-    where
-        S: Sink<tungstenite::Message, Error = tungstenite::Error>
-            + Stream<Item = Result<tungstenite::Message, tungstenite::Error>>
-            + Send
-            + 'static,
-    {
-        // We have to do a bunch of acrobatics here. The `connect_stream` call expects a stream and
-        // a sink. However, we need to intercept the stream of websocket messages and if we see a
-        // ping we need to immediately send a pong. Intercepting the stream is straightforward, we
-        // just filter it and only forward decoded binary messages but as a side effect send pongs
-        // back to the server whenever we see one. This last part makes the sink side of things
-        // tricky though. We can't just use the sink from the filter because we also have to pass
-        // the sink to the `connect_stream` call.
-        //
-        // To get around this we create a channel. We can then create a sink from the sender side
-        // of the channel and pass that to `connect_stream` and we can also push to the channel
-        // from the filter. Then we create a future which pulls from the other end of the channel
-        // and sends to the websocket sink. This is the future that we return from this function.
-        use tokio_util::sync::PollSender;
-
-        let (mut sink, stream) = stream.split();
-
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<tungstenite::Message>(1);
-
-        let msg_stream = stream
-            .filter_map::<_, Result<Message, NetworkError>, _>({
-                let tx = tx.clone();
-                move |msg| {
-                    let tx = tx.clone();
-                    async move {
-                        let msg = match msg {
-                            Ok(m) => m,
-                            Err(e) => {
-                                return Some(Err(NetworkError::Error(format!(
-                                    "websocket receive error: {}",
-                                    e
-                                ))));
-                            }
-                        };
-                        match msg {
-                            tungstenite::Message::Binary(data) => Some(Message::decode(&data).map_err(|e| {
-                                tracing::error!(err=?e, msg=%hex::encode(data), "error decoding message");
-                                NetworkError::Error(format!("error decoding message: {}", e))
-                            })),
-                            tungstenite::Message::Close(_) => {
-                                tracing::debug!("websocket closing");
-                                None
-                            }
-                            tungstenite::Message::Ping(ping_data) => {
-                                let pong_response = tungstenite::Message::Pong(ping_data);
-                                tx.send(pong_response).await.ok();
-                                None
-                            },
-                            tungstenite::Message::Pong(_) => None,
-                            tungstenite::Message::Text(_) => {
-                                Some(Err(NetworkError::Error("unexpected string message on websocket".to_string())))
-                            },
-                            tungstenite::Message::Frame(_) => unreachable!(),
-                        }
-                    }
-                }
-            }).boxed();
-
-        let msg_sink = PollSender::new(tx.clone())
-            .sink_map_err(|e| NetworkError::Error(format!("websocket send error: {}", e)))
-            .with(|msg: Message| {
-                futures::future::ready(Ok::<_, NetworkError>(tungstenite::Message::Binary(
-                    msg.encode(),
-                )))
-            });
-
-        let connecting = self.connect_stream(msg_stream, msg_sink, direction);
-
-        let mut do_send = Box::pin(
-            async move {
-                while let Some(msg) = rx.recv().await {
-                    if let Err(e) = sink.send(msg).await {
-                        tracing::error!(err=?e, "error sending message");
-                        return Err(CodecError::Network(NetworkError::Error(format!(
-                            "error sending message: {}",
-                            e
-                        ))));
-                    }
-                }
-                Ok(())
-            }
-            .fuse(),
-        );
-
-        futures::select! {
-            res = connecting.fuse() => {
-                res?;
-            },
-            res = do_send => {
-                match res {
-                    Err(e) => {
-                        tracing::error!(err=?e, "error sending message");
-                        return Err(CodecError::Network(NetworkError::Error(format!("error sending message: {}", e))));
-                    }
-                    Ok(()) => {
-                        tracing::error!("websocket send loop unexpectedly stopped");
-                        return Err(CodecError::Network(NetworkError::Error("websocket send loop unexpectedly stopped".to_string())));
-                    }
-                }
-            },
-        }
-
-        Ok(do_send)
     }
 }
 

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -8,7 +8,7 @@ use crate::{repo::RepoHandle, ConnDirection};
 use crate::{Message, NetworkError};
 
 #[cfg(feature = "tungstenite")]
-use futures::{Sink, SinkExt, Stream, StreamExt};
+use futures::{Future, FutureExt, Sink, SinkExt, Stream, StreamExt};
 
 mod fs_storage;
 pub use fs_storage::FsStorage;
@@ -35,35 +35,102 @@ impl RepoHandle {
         Ok(())
     }
 
+    /// Connect a websocket
+    ///
+    /// This function waits until the initial handshake is complete and then returns a future which
+    /// must be driven to completion to keep the connection alive. The returned future is required
+    /// so that we continue to respond to pings from the server which will otherwise disconnect us.
+    ///
+    /// ## Example
+    ///
+    /// ```no_run
+    /// use automerge_repo::{Repo, RepoHandle, ConnDirection, Storage};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///    let storage: Box<dyn Storage> = unimplemented!();
+    ///    let repo = Repo::new(None, storage);
+    ///    let handle = repo.run();
+    ///    let (conn, _) = tokio_tungstenite::connect_async("ws://localhost:8080").await.unwrap();
+    ///    let conn_driver = handle.connect_tungstenite(conn, ConnDirection::Outgoing).await.unwrap();
+    ///    tokio::spawn(async move {
+    ///        if let Err(e) = conn_driver.await {
+    ///            eprintln!("Error running repo connection: {}", e);
+    ///        }
+    ///    });
+    ///    // ...
+    /// }
+    /// ```
     #[cfg(feature = "tungstenite")]
     pub async fn connect_tungstenite<S>(
         &self,
         stream: S,
         direction: ConnDirection,
-    ) -> Result<(), CodecError>
+    ) -> Result<impl Future<Output = Result<(), CodecError>>, CodecError>
     where
         S: Sink<tungstenite::Message, Error = tungstenite::Error>
             + Stream<Item = Result<tungstenite::Message, tungstenite::Error>>
             + Send
             + 'static,
     {
-        let (sink, stream) = stream.split();
+        // We have to do a bunch of acrobatics here. The `connect_stream` call expects a stream and
+        // a sink. However, we need to intercept the stream of websocket messages and if we see a
+        // ping we need to immediately send a pong. Intercepting the stream is straightforward, we
+        // just filter it and only forward decoded binary messages but as a side effect send pongs
+        // back to the server whenever we see one. This last part makes the sink side of things
+        // tricky though. We can't just use the sink from the filter because we also have to pass
+        // the sink to the `connect_stream` call.
+        //
+        // To get around this we create a channel. We can then create a sink from the sender side
+        // of the channel and pass that to `connect_stream` and we can also push to the channel
+        // from the filter. Then we create a future which pulls from the other end of the channel
+        // and sends to the websocket sink. This is the future that we return from this function.
+        use tokio_util::sync::PollSender;
 
-        let msg_stream = stream.map::<Result<Message, NetworkError>, _>(|msg| {
-            let msg =
-                msg.map_err(|e| NetworkError::Error(format!("websocket receive error: {}", e)))?;
-            match msg {
-                tungstenite::Message::Binary(data) => Message::decode(&data).map_err(|e| {
-                    tracing::error!(err=?e, msg=%hex::encode(data), "error decoding message");
-                    NetworkError::Error(format!("error decoding message: {}", e))
-                }),
-                _ => Err(NetworkError::Error(
-                    "unexpected non-binary message".to_string(),
-                )),
-            }
-        });
+        let (mut sink, stream) = stream.split();
 
-        let sink = sink
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<tungstenite::Message>(1);
+
+        let msg_stream = stream
+            .filter_map::<_, Result<Message, NetworkError>, _>({
+                let tx = tx.clone();
+                move |msg| {
+                    let tx = tx.clone();
+                    async move {
+                        let msg = match msg {
+                            Ok(m) => m,
+                            Err(e) => {
+                                return Some(Err(NetworkError::Error(format!(
+                                    "websocket receive error: {}",
+                                    e
+                                ))));
+                            }
+                        };
+                        match msg {
+                            tungstenite::Message::Binary(data) => Some(Message::decode(&data).map_err(|e| {
+                                tracing::error!(err=?e, msg=%hex::encode(data), "error decoding message");
+                                NetworkError::Error(format!("error decoding message: {}", e))
+                            })),
+                            tungstenite::Message::Close(_) => {
+                                tracing::debug!("websocket closing");
+                                None
+                            }
+                            tungstenite::Message::Ping(ping_data) => {
+                                let pong_response = tungstenite::Message::Pong(ping_data);
+                                tx.send(pong_response).await.ok();
+                                None
+                            },
+                            tungstenite::Message::Pong(_) => None,
+                            tungstenite::Message::Text(_) => {
+                                Some(Err(NetworkError::Error("unexpected string message on websocket".to_string())))
+                            },
+                            tungstenite::Message::Frame(_) => unreachable!(),
+                        }
+                    }
+                }
+            }).boxed();
+
+        let msg_sink = PollSender::new(tx.clone())
             .sink_map_err(|e| NetworkError::Error(format!("websocket send error: {}", e)))
             .with(|msg: Message| {
                 futures::future::ready(Ok::<_, NetworkError>(tungstenite::Message::Binary(
@@ -71,9 +138,43 @@ impl RepoHandle {
                 )))
             });
 
-        self.connect_stream(msg_stream, sink, direction).await?;
+        let connecting = self.connect_stream(msg_stream, msg_sink, direction);
 
-        Ok(())
+        let mut do_send = Box::pin(
+            async move {
+                while let Some(msg) = rx.recv().await {
+                    if let Err(e) = sink.send(msg).await {
+                        tracing::error!(err=?e, "error sending message");
+                        return Err(CodecError::Network(NetworkError::Error(format!(
+                            "error sending message: {}",
+                            e
+                        ))));
+                    }
+                }
+                Ok(())
+            }
+            .fuse(),
+        );
+
+        futures::select! {
+            res = connecting.fuse() => {
+                res?;
+            },
+            res = do_send => {
+                match res {
+                    Err(e) => {
+                        tracing::error!(err=?e, "error sending message");
+                        return Err(CodecError::Network(NetworkError::Error(format!("error sending message: {}", e))));
+                    }
+                    Ok(()) => {
+                        tracing::error!("websocket send loop unexpectedly stopped");
+                        return Err(CodecError::Network(NetworkError::Error("websocket send loop unexpectedly stopped".to_string())));
+                    }
+                }
+            },
+        }
+
+        Ok(do_send)
     }
 }
 

--- a/src/tokio/websocket.rs
+++ b/src/tokio/websocket.rs
@@ -1,0 +1,293 @@
+use futures::{Future, FutureExt, Sink, SinkExt, Stream, StreamExt};
+use tokio_util::sync::PollSender;
+
+use crate::{ConnDirection, Message, NetworkError, RepoHandle};
+
+/// A copy of tungstenite::Message
+///
+/// This is necessary because axum uses tungstenite::Message internally but exposes it's own
+/// version so in order to have the logic which handles tungstenite clients and axum servers
+/// written in the same function we have to map both the tungstenite `Message` and the axum
+/// `Message` to our own type.
+pub(crate) enum WsMessage {
+    Binary(Vec<u8>),
+    Text(String),
+    Close,
+    Ping(Vec<u8>),
+    Pong(Vec<u8>),
+}
+
+#[cfg(feature = "tungstenite")]
+impl From<WsMessage> for tungstenite::Message {
+    fn from(msg: WsMessage) -> Self {
+        match msg {
+            WsMessage::Binary(data) => tungstenite::Message::Binary(data),
+            WsMessage::Text(data) => tungstenite::Message::Text(data),
+            WsMessage::Close => tungstenite::Message::Close(None),
+            WsMessage::Ping(data) => tungstenite::Message::Ping(data),
+            WsMessage::Pong(data) => tungstenite::Message::Pong(data),
+        }
+    }
+}
+
+#[cfg(feature = "tungstenite")]
+impl From<tungstenite::Message> for WsMessage {
+    fn from(msg: tungstenite::Message) -> Self {
+        match msg {
+            tungstenite::Message::Binary(data) => WsMessage::Binary(data),
+            tungstenite::Message::Text(data) => WsMessage::Text(data),
+            tungstenite::Message::Close(_) => WsMessage::Close,
+            tungstenite::Message::Ping(data) => WsMessage::Ping(data),
+            tungstenite::Message::Pong(data) => WsMessage::Pong(data),
+            tungstenite::Message::Frame(_) => unreachable!("unexpected frame message"),
+        }
+    }
+}
+
+#[cfg(feature = "axum")]
+impl From<WsMessage> for axum::extract::ws::Message {
+    fn from(msg: WsMessage) -> Self {
+        match msg {
+            WsMessage::Binary(data) => axum::extract::ws::Message::Binary(data),
+            WsMessage::Text(data) => axum::extract::ws::Message::Text(data),
+            WsMessage::Close => axum::extract::ws::Message::Close(None),
+            WsMessage::Ping(data) => axum::extract::ws::Message::Ping(data),
+            WsMessage::Pong(data) => axum::extract::ws::Message::Pong(data),
+        }
+    }
+}
+
+#[cfg(feature = "axum")]
+impl From<axum::extract::ws::Message> for WsMessage {
+    fn from(msg: axum::extract::ws::Message) -> Self {
+        match msg {
+            axum::extract::ws::Message::Binary(data) => WsMessage::Binary(data),
+            axum::extract::ws::Message::Text(data) => WsMessage::Text(data),
+            axum::extract::ws::Message::Close(_) => WsMessage::Close,
+            axum::extract::ws::Message::Ping(data) => WsMessage::Ping(data),
+            axum::extract::ws::Message::Pong(data) => WsMessage::Pong(data),
+        }
+    }
+}
+
+impl RepoHandle {
+    /// Connect a websocket
+    ///
+    /// This function waits until the initial handshake is complete and then returns a future which
+    /// must be driven to completion to keep the connection alive. The returned future is required
+    /// so that we continue to respond to pings from the server which will otherwise disconnect us.
+    ///
+    /// ## Example
+    ///
+    /// ```no_run
+    /// use automerge_repo::{Repo, RepoHandle, ConnDirection, Storage};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///    let storage: Box<dyn Storage> = unimplemented!();
+    ///    let repo = Repo::new(None, storage);
+    ///    let handle = repo.run();
+    ///    let (conn, _) = tokio_tungstenite::connect_async("ws://localhost:8080").await.unwrap();
+    ///    let conn_driver = handle.connect_tungstenite(conn, ConnDirection::Outgoing).await.unwrap();
+    ///    tokio::spawn(async move {
+    ///        if let Err(e) = conn_driver.await {
+    ///            eprintln!("Error running repo connection: {}", e);
+    ///        }
+    ///    });
+    ///    // ...
+    /// }
+    /// ```
+    #[cfg(feature = "tungstenite")]
+    pub async fn connect_tungstenite<S>(
+        &self,
+        stream: S,
+        direction: ConnDirection,
+    ) -> Result<impl Future<Output = Result<(), NetworkError>>, NetworkError>
+    where
+        S: Sink<tungstenite::Message, Error = tungstenite::Error>
+            + Stream<Item = Result<tungstenite::Message, tungstenite::Error>>
+            + Send
+            + 'static,
+    {
+        use futures::TryStreamExt;
+
+        let stream = stream
+            .map_err(|e| NetworkError::Error(format!("error receiving websocket message: {}", e)))
+            .sink_map_err(|e| {
+                NetworkError::Error(format!("error sending websocket message: {}", e))
+            });
+        self.connect_tokio_websocket(stream, direction).await
+    }
+
+    /// Accept a websocket in an axum handler
+    ///
+    /// This function waits until the initial handshake is complete and then returns a future which
+    /// must be driven to completion to keep the connection alive.
+    ///
+    /// ## Example
+    ///
+    /// ```no_run
+    /// use automerge_repo::{Repo, RepoHandle, ConnDirection, Storage};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let storage: Box<dyn Storage> = unimplemented!();
+    ///     let handle = Repo::new(None, storage).run();
+    ///     let app = axum::Router::new()
+    ///         .route("/", axum::routing::get(websocket_handler))
+    ///         .with_state(handle.clone());
+    ///     let server = axum::Server::bind(&"0.0.0.0:0".parse().unwrap()).serve(app.into_make_service());
+    ///     let port = server.local_addr().port();
+    ///     tokio::spawn(server);
+    /// }
+    ///
+    /// async fn websocket_handler(
+    ///     ws: axum::extract::ws::WebSocketUpgrade,
+    ///     axum::extract::State(handle): axum::extract::State<RepoHandle>,
+    /// ) -> axum::response::Response {
+    ///     ws.on_upgrade(|socket| handle_socket(socket, handle))
+    /// }
+    ///
+    /// async fn handle_socket(
+    ///     socket: axum::extract::ws::WebSocket,
+    ///     repo: RepoHandle,
+    /// ) {
+    ///     let driver = repo
+    ///         .accept_axum(socket)
+    ///         .await
+    ///         .unwrap();
+    ///     tokio::spawn(async {
+    ///         if let Err(e) = driver.await {
+    ///             tracing::error!("Error running connection: {}", e);
+    ///         }
+    ///     });
+    /// }
+    /// ```
+    #[cfg(feature = "axum")]
+    pub async fn accept_axum<S>(
+        &self,
+        stream: S,
+    ) -> Result<impl Future<Output = Result<(), NetworkError>>, NetworkError>
+    where
+        S: Sink<axum::extract::ws::Message, Error = axum::Error>
+            + Stream<Item = Result<axum::extract::ws::Message, axum::Error>>
+            + Send
+            + 'static,
+    {
+        use futures::TryStreamExt;
+
+        let stream = stream
+            .map_err(|e| NetworkError::Error(format!("error receiving websocket message: {}", e)))
+            .sink_map_err(|e| {
+                NetworkError::Error(format!("error sending websocket message: {}", e))
+            });
+        self.connect_tokio_websocket(stream, ConnDirection::Incoming)
+            .await
+    }
+
+    pub(crate) async fn connect_tokio_websocket<S, M>(
+        &self,
+        stream: S,
+        direction: ConnDirection,
+    ) -> Result<impl Future<Output = Result<(), NetworkError>>, NetworkError>
+    where
+        M: Into<WsMessage> + From<WsMessage> + Send + 'static,
+        S: Sink<M, Error = NetworkError> + Stream<Item = Result<M, NetworkError>> + Send + 'static,
+    {
+        // We have to do a bunch of acrobatics here. The `connect_stream` call expects a stream and
+        // a sink. However, we need to intercept the stream of websocket messages and if we see a
+        // ping we need to immediately send a pong. Intercepting the stream is straightforward, we
+        // just filter it and only forward decoded binary messages but as a side effect send pongs
+        // back to the server whenever we see a ping. This last part makes the sink side of things
+        // tricky though. We can't just use the sink from the filter because we also have to pass
+        // the sink to the `connect_stream` call.
+        //
+        // To get around this we create a channel. We can then create a sink from the sender side
+        // of the channel and pass that to `connect_stream` and we can also push to the channel
+        // from the filter. Then we create a future which pulls from the other end of the channel
+        // and sends to the websocket sink. This is the future that we return from this function.
+
+        let (mut sink, stream) = stream.split();
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<WsMessage>(1);
+
+        let msg_stream = stream
+            .filter_map::<_, Result<Message, NetworkError>, _>({
+                let tx = tx.clone();
+                move |msg| {
+                    let tx = tx.clone();
+                    async move {
+                        let msg = match msg {
+                            Ok(m) => m,
+                            Err(e) => {
+                                return Some(Err(NetworkError::Error(format!(
+                                    "websocket receive error: {}",
+                                    e
+                                ))));
+                            }
+                        };
+                        match msg.into() {
+                            WsMessage::Binary(data) => Some(Message::decode(&data).map_err(|e| {
+                                tracing::error!(err=?e, msg=%hex::encode(data), "error decoding message");
+                                NetworkError::Error(format!("error decoding message: {}", e))
+                            })),
+                            WsMessage::Close => {
+                                tracing::debug!("websocket closing");
+                                None
+                            }
+                            WsMessage::Ping(ping_data) => {
+                                let pong_response = WsMessage::Pong(ping_data);
+                                tx.send(pong_response).await.ok();
+                                None
+                            },
+                            WsMessage::Pong(_) => None,
+                            WsMessage::Text(_) => {
+                                Some(Err(NetworkError::Error("unexpected string message on websocket".to_string())))
+                            },
+                        }
+                    }
+                }
+            }).boxed();
+
+        let msg_sink = PollSender::new(tx.clone())
+            .sink_map_err(|e| NetworkError::Error(format!("websocket send error: {}", e)))
+            .with(|msg: Message| {
+                futures::future::ready(Ok::<_, NetworkError>(WsMessage::Binary(msg.encode())))
+            });
+
+        let connecting = self.connect_stream(msg_stream, msg_sink, direction);
+
+        let mut do_send = Box::pin(
+            async move {
+                while let Some(msg) = rx.recv().await {
+                    if let Err(e) = sink.send(msg.into()).await {
+                        tracing::error!(err=?e, "error sending message");
+                        return Err(NetworkError::Error(format!("error sending message: {}", e)));
+                    }
+                }
+                Ok(())
+            }
+            .fuse(),
+        );
+
+        futures::select! {
+            res = connecting.fuse() => {
+                res?;
+            },
+            res = do_send => {
+                match res {
+                    Err(e) => {
+                        tracing::error!(err=?e, "error sending message");
+                        return Err(NetworkError::Error(format!("error sending message: {}", e)));
+                    }
+                    Ok(()) => {
+                        tracing::error!("websocket send loop unexpectedly stopped");
+                        return Err(NetworkError::Error("websocket send loop unexpectedly stopped".to_string()));
+                    }
+                }
+            },
+        }
+
+        Ok(do_send)
+    }
+}


### PR DESCRIPTION
This PR does two things:

1. Enhance the websocket handling code to respond to pings. This is necessary because websocket servers (such as the automerge-repo JS websocket server) will close connections which do not respond to pings. This requires changing the API of `connect_tungstenite` so that it returns a `Future` which must be driven to continue responding to pings.
2. Add a method on `Repo` for accepting an `axum` websocket stream. This is behind a feature flag called `axum`.