### PR TITLE
Use base58 encoded UUIDs for document IDs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ tracing = "0.1.37"
 ring = "0.16.20"
 hex = "0.4.3"
 tempfile = "3.6.0"
+bs58 = { version = "0.5.0", features = ["check"] }
 
 [dev-dependencies]
 clap = { version = "4.2.5", features = ["derive"] }

--- a/src/fs_store.rs
+++ b/src/fs_store.rs
@@ -3,7 +3,6 @@ use std::{
     fs::File,
     io::Write,
     path::{Path, PathBuf},
-    str,
 };
 
 use crate::DocumentId;
@@ -314,8 +313,10 @@ impl DocIdPaths {
 
         let level2 = level2.file_name()?.to_str()?;
         let doc_id_bytes = hex::decode(level2).ok()?;
-        let doc_id_str = str::from_utf8(&doc_id_bytes).ok()?;
-        let doc_id = DocumentId::from(doc_id_str);
+        let Ok(doc_id) = DocumentId::try_from(doc_id_bytes) else {
+            tracing::error!(level2_path=%level2, "invalid document ID");
+            return None;
+        };
         let result = Self::from(&doc_id);
         if result.prefix != prefix {
             None

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -135,7 +135,7 @@ impl RepoHandle {
 
     /// Create a new document.
     pub fn new_document(&self) -> DocHandle {
-        let document_id = DocumentId(Uuid::new_v4().to_string());
+        let document_id = DocumentId::random();
         let document = new_document();
         let doc_info = self.new_document_info(document, DocState::LocallyCreatedNotEdited);
         let handle = DocHandle::new(

--- a/tests/fs_storage/main.rs
+++ b/tests/fs_storage/main.rs
@@ -29,7 +29,7 @@ fn fs_store_crud() {
     doc.put(automerge::ObjId::Root, "key", "value").unwrap();
     let mut change1 = doc.get_last_local_change().unwrap().clone();
 
-    let doc_id = automerge_repo::DocumentId::from("somedoc");
+    let doc_id = automerge_repo::DocumentId::random();
     store.append(&doc_id, change1.bytes().as_ref()).unwrap();
     let result = store.get(&doc_id).unwrap().unwrap();
     assert_eq!(&result, change1.bytes().as_ref());
@@ -55,7 +55,7 @@ fn fs_store_crud() {
     assert_eq!(result, expected);
 
     // check nonexistent docs don't upset anyone
-    let nonexistent_doc_id = automerge_repo::DocumentId::from("nonexistent");
+    let nonexistent_doc_id = automerge_repo::DocumentId::random();
     let result = store.get(&nonexistent_doc_id).unwrap();
     assert!(result.is_none());
 }

--- a/tests/network/document_load.rs
+++ b/tests/network/document_load.rs
@@ -126,7 +126,7 @@ async fn test_loading_document_immediately_not_found() {
     let repo_handle = repo.run();
 
     // Spawn a task that awaits the requested doc handle.
-    let doc_id = DocumentId::from("doc1");
+    let doc_id = DocumentId::random();
     assert!(repo_handle.load(doc_id).await.unwrap().is_none());
     // Shut down the repo.
     repo_handle.stop().unwrap();
@@ -142,7 +142,7 @@ async fn test_loading_document_not_found_async() {
     let repo_handle = repo.run();
 
     // Spawn a task that awaits the requested doc handle.
-    let doc_id = DocumentId::from("doc1");
+    let doc_id = DocumentId::random();
     assert!(repo_handle.load(doc_id).await.unwrap().is_none());
     // Shut down the repo.
     tokio::task::spawn_blocking(|| {


### PR DESCRIPTION
Problem: the automerge-repo JS implementation uses base68 encoded UUIDs for it's document IDs. In this library we accept arbitrary strings.

Solution: In preparation for full compatibility with the JS implementation constrain document IDs to be a UUID. This shouldn't have any compatibility problems for most users because by default when we create a document ID we use a UUID.