### PR TITLE
Load documents when receiving new network events

### DIFF
--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1668,7 +1668,18 @@ impl Repo {
                             };
                             let document = Arc::new(RwLock::new(shared_document));
                             let handle_count = Arc::new(AtomicUsize::new(0));
-                            DocumentInfo::new(state, document, handle_count)
+                            let mut info = DocumentInfo::new(state, document, handle_count);
+
+                            let storage_fut = self.storage.get(document_id.clone());
+                            info.state.add_boostrap_storage_fut(storage_fut);
+                            info.poll_storage_operation(
+                                document_id.clone(),
+                                &self.wake_sender,
+                                &self.repo_sender,
+                                &self.repo_id,
+                            );
+
+                            info
                         });
 
                     if !info.state.should_sync() {

--- a/test_utils/src/storage_utils.rs
+++ b/test_utils/src/storage_utils.rs
@@ -50,6 +50,12 @@ impl InMemoryStorage {
     pub fn contains_document(&self, doc_id: DocumentId) -> bool {
         self.documents.lock().contains_key(&doc_id)
     }
+
+    pub fn fork(&self) -> Self {
+        Self {
+            documents: Arc::new(Mutex::new(self.documents.lock().clone())),
+        }
+    }
 }
 
 impl Storage for InMemoryStorage {


### PR DESCRIPTION
Problem: when a peer responds to sync messages for a document which it has not currently loaded it doesn't attempt to load the document from disk. This means that attempting to request a document whilst simultanously syncing it with another machine could result in the dochandle resolving to an empty document.

Solution: ensure that the document is loaded if not already loaded when the sync message is received.