### PR TITLE
Add missing impls to DocumentId and Permissive

### DIFF
--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -21,7 +21,7 @@ impl<'a> From<&'a str> for RepoId {
     }
 }
 
-#[derive(Eq, Hash, PartialEq, Clone, Deserialize, Serialize)]
+#[derive(Eq, Hash, PartialEq, Clone, Copy, Deserialize, Serialize)]
 pub struct DocumentId([u8; 16]);
 
 impl DocumentId {

--- a/src/share_policy.rs
+++ b/src/share_policy.rs
@@ -176,6 +176,7 @@ where
 }
 
 /// A share policy which always shares documents with all peers
+#[derive(Debug, Clone, Copy)]
 pub struct Permissive;
 
 impl SharePolicy for Permissive {


### PR DESCRIPTION
I was writing a little helper library for Keyhive, and noticed that `DocumentId` didn't have a `Copy` despite (currently) being `[u8; 16]` under the hood. That may be intentional, but figured I'd PR the small change in case it's helpful for others :)